### PR TITLE
Adds "help" kwargs in order to provide usage information.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changes:
 ^^^^^^^^
 
 - Added ``environ.generate_help`` to the public interface. It is implemented by...
+
   * ``environ._environ_config.generate_help``
   * ``environ._environ_config._generate_help_dicts``
   * ``environ._environ_config._format_help_dicts``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,10 @@ Backward-incompatible changes:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``environ.generate_help`` to the public interface. It is implemented by...
+  * ``environ._environ_config.generate_help``
+  * ``environ._environ_config._generate_help_dicts``
+  * ``environ._environ_config._format_help_dicts``
 
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,31 @@ Features
   * `HashiCorp Vault <https://www.vaultproject.io>`_ support via `envconsul <https://github.com/hashicorp/envconsul>`_.
   * INI files, because secrets in env variables are `icky <https://diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/>`_.
 - Pass any dict into `environ.to_config(AppConfig, {"your": "config"})` instead of loading from the environment.
+- Built in dynamic help documentation generation via ``environ.generate_help``.
+
+.. code-block:: pycon
+
+  >>> import environ
+  >>> @environ.config(prefix="APP")
+  ... class AppConfig:
+  ...     @environ.config
+  ...     class SubConfig:
+  ...         sit = environ.var(help="Another example message.")
+  ...         amet = environ.var()
+  ...     lorem = environ.var('ipsum')
+  ...     dolor = environ.bool_var(True, help="An example message.")
+  ...     subconfig = environ.group(SubConfig)
+  ...
+  >>> print(environ.generate_help(AppConfig))
+  APP_LOREM (Optional)
+  APP_DOLOR (Optional): An example message.
+  APP_SUBCONFIG_SIT (Required): Another example message.
+  APP_SUBCONFIG_AMET (Required)
+  >>> print(environ.generate_help(AppConfig, display_defaults=True))
+  APP_LOREM (Optional, Default=ipsum)
+  APP_DOLOR (Optional, Default=True): An example message.
+  APP_SUBCONFIG_SIT (Required): Another example message.
+  APP_SUBCONFIG_AMET (Required)
 
 
 Project Information

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,9 @@ license_file = LICENSE
 atomic=true
 lines_after_imports=2
 lines_between_types=1
-multi_line_output=5
+multi_line_output=3
 not_skip=__init__.py
+include_trailing_comma=True
 
 known_first_party=environ
 known_third_party=attr,pytest,setuptools

--- a/src/environ/__init__.py
+++ b/src/environ/__init__.py
@@ -1,5 +1,12 @@
 from . import secrets
-from ._environ_config import bool_var, config, group, to_config, var
+from ._environ_config import (
+    bool_var,
+    config,
+    generate_help,
+    group,
+    to_config,
+    var,
+)
 from .exceptions import MissingEnvValueError
 
 
@@ -20,6 +27,7 @@ __all__ = [
     "MissingEnvValueError",
     "bool_var",
     "config",
+    "generate_help",
     "group",
     "secrets",
     "to_config",

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -39,12 +39,13 @@ class _ConfigEntry(object):
     default = attr.ib(default=RAISE)
     sub_cls = attr.ib(default=None)
     callback = attr.ib(default=None)
+    help = attr.ib(default=None)
 
 
-def var(default=RAISE, converter=None, name=None, validator=None):
+def var(default=RAISE, converter=None, name=None, validator=None, help=None):
     return attr.ib(
         default=default,
-        metadata={CNF_KEY: _ConfigEntry(name, default, None)},
+        metadata={CNF_KEY: _ConfigEntry(name, default, None, None, help)},
         converter=converter,
         validator=validator,
     )
@@ -63,8 +64,8 @@ def _env_to_bool(val):
     return False
 
 
-def bool_var(default=RAISE, name=None):
-    return var(default=default, name=name, converter=_env_to_bool)
+def bool_var(default=RAISE, name=None, help=None):
+    return var(default=default, name=name, converter=_env_to_bool, help=help)
 
 
 def group(cls):
@@ -115,3 +116,86 @@ def _to_config(config_cls, default_get, environ, prefix):
 
         vals[a.name] = val
     return config_cls(**vals)
+
+
+def _format_help_dicts(help_dicts, display_defaults=False):
+    """
+    Format the output of _generate_help_dicts into a str
+    """
+    help_strs = []
+    for help_dict in help_dicts:
+        help_str = "%s (%s" % (
+            help_dict["var_name"],
+            "Required" if help_dict["required"] else "Optional",
+        )
+        if help_dict.get("default") and display_defaults:
+            help_str += ", Default=%s)" % help_dict["default"]
+        else:
+            help_str += ")"
+        if help_dict.get("help_str"):
+            help_str += ": %s" % help_dict["help_str"]
+        help_strs.append(help_str)
+
+    return "\n".join(help_strs)
+
+
+def _generate_help_dicts(config_cls, _prefix=None):
+    """
+    Generate dictionaries for use in building help strings.
+
+    Every dictionary includes the keys...
+
+    var_name: The env var that should be set to populate the value.
+    required: A bool, True if the var is required, False if it's optional.
+
+    Conditionally, the following are included...
+
+    default: Included if an optional variable has a default set
+    help_str: Included if the var uses the help kwarg to provide additional
+        context for the value.
+
+    Conditional key inclusion is meant to differentiate between exclusion
+    vs explicitly setting a value to None.
+    """
+    help_dicts = []
+    if _prefix is None:
+        _prefix = config_cls._prefix
+    for a in attr.fields(config_cls):
+        try:
+            ce = a.metadata[CNF_KEY]
+        except KeyError:
+            continue
+        if ce.sub_cls is None:  # Base case for "leaves".
+            if ce.name is None:
+                var_name = "_".join((_prefix, a.name)).upper()
+            else:
+                var_name = ce.name
+            req = ce.default == RAISE
+            help_dict = {"var_name": var_name, "required": req}
+            if not req:
+                help_dict["default"] = ce.default
+            if ce.help is not None:
+                help_dict["help_str"] = ce.help
+            help_dicts.append(help_dict)
+        else:  # Construct the new prefix and recurse.
+            help_dicts += _generate_help_dicts(
+                ce.sub_cls, _prefix="_".join((_prefix, a.name)).upper()
+            )
+    return help_dicts
+
+
+def generate_help(config_cls, **kwargs):
+    """
+    Autogenerate a help string for a config class.
+
+    If a callable is provided via the "formatter" kwarg it
+    will be provided with the help dictionaries as an argument
+    and any other kwargs provided to this function. That callable
+    should return the help text string.
+    """
+    try:
+        formatter = kwargs.pop("formatter")
+    except KeyError:
+        formatter = _format_help_dicts
+    help_dicts = _generate_help_dicts(config_cls)
+    return formatter(help_dicts, **kwargs)

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -38,14 +38,16 @@ class INISecrets(object):
         """
         return cls(section, None, env_name, default)
 
-    def secret(self, default=RAISE, converter=None, name=None, section=None):
+    def secret(
+        self, default=RAISE, converter=None, name=None, section=None, help=None
+    ):
         if section is None:
             section = self.section
 
         return attr.ib(
             default=default,
             metadata={
-                CNF_KEY: _ConfigEntry(name, default, None, self._get),
+                CNF_KEY: _ConfigEntry(name, default, None, self._get, help),
                 CNF_INI_SECRET_KEY: _INIConfig(section),
             },
             converter=converter,
@@ -84,10 +86,12 @@ class VaultEnvSecrets(object):
 
     vault_prefix = attr.ib()
 
-    def secret(self, default=RAISE, converter=None, name=None):
+    def secret(self, default=RAISE, converter=None, name=None, help=None):
         return attr.ib(
             default=default,
-            metadata={CNF_KEY: _ConfigEntry(name, default, None, self._get)},
+            metadata={
+                CNF_KEY: _ConfigEntry(name, default, None, self._get, help)
+            },
             converter=converter,
         )
 

--- a/tests/test_environ_config.py
+++ b/tests/test_environ_config.py
@@ -20,6 +20,32 @@ class Nested(object):
     sub = environ.group(Sub)
 
 
+@environ.config(prefix="FOO")
+class Parent(object):
+    not_a_var = attr.ib()  # For testing that only environ.var's are processed.
+    var1 = environ.var(help="var1, no default")
+    var2 = environ.var("bar", help="var2, has default")
+    var3 = environ.bool_var(help="var3, bool_var, no default")
+    var4 = environ.bool_var(True, help="var4, bool_var, has default")
+    var5 = environ.var("canine", name="DOG", help="var5, named, has default")
+    var6 = environ.var(name="CAT", help="var6, named, no default")
+
+    @environ.config
+    class Child(object):
+        var7 = environ.var(help="var7, no default")
+        var8 = environ.var("bar", help="var8, has default")
+        var9 = environ.bool_var(help="var9, bool_var, no default")
+        var10 = environ.bool_var(True, help="var10, bool_var, has default")
+        var11 = environ.var(
+            "canine", name="DOG2", help="var11, named, has default"
+        )
+        var12 = environ.var(name="CAT2", help="var12, named, no default")
+        var13 = environ.var("default")  # var with default, no help
+        var14 = environ.var()  # var without default, no help
+
+    child = environ.group(Child)
+
+
 class TestEnvironConfig(object):
     def test_empty(self):
         """
@@ -170,3 +196,50 @@ class TestEnvironConfig(object):
         cfg = environ.to_config(Cfg, environ={"APP_E": "e"})
 
         assert Cfg("e", 42) == cfg
+
+    def test_generate_help_str(self):
+        help_str = environ.generate_help(Parent)
+        assert (
+            help_str
+            == """FOO_VAR1 (Required): var1, no default
+FOO_VAR2 (Optional): var2, has default
+FOO_VAR3 (Required): var3, bool_var, no default
+FOO_VAR4 (Optional): var4, bool_var, has default
+DOG (Optional): var5, named, has default
+CAT (Required): var6, named, no default
+FOO_CHILD_VAR7 (Required): var7, no default
+FOO_CHILD_VAR8 (Optional): var8, has default
+FOO_CHILD_VAR9 (Required): var9, bool_var, no default
+FOO_CHILD_VAR10 (Optional): var10, bool_var, has default
+DOG2 (Optional): var11, named, has default
+CAT2 (Required): var12, named, no default
+FOO_CHILD_VAR13 (Optional)
+FOO_CHILD_VAR14 (Required)"""
+        )
+
+    def test_generate_help_str_with_defaults(self):
+        help_str = environ.generate_help(Parent, display_defaults=True)
+        assert (
+            help_str
+            == """FOO_VAR1 (Required): var1, no default
+FOO_VAR2 (Optional, Default=bar): var2, has default
+FOO_VAR3 (Required): var3, bool_var, no default
+FOO_VAR4 (Optional, Default=True): var4, bool_var, has default
+DOG (Optional, Default=canine): var5, named, has default
+CAT (Required): var6, named, no default
+FOO_CHILD_VAR7 (Required): var7, no default
+FOO_CHILD_VAR8 (Optional, Default=bar): var8, has default
+FOO_CHILD_VAR9 (Required): var9, bool_var, no default
+FOO_CHILD_VAR10 (Optional, Default=True): var10, bool_var, has default
+DOG2 (Optional, Default=canine): var11, named, has default
+CAT2 (Required): var12, named, no default
+FOO_CHILD_VAR13 (Optional, Default=default)
+FOO_CHILD_VAR14 (Required)"""
+        )
+
+    def test_custom_formatter(self):
+        def bad_formatter(help_dicts):
+            return "Not a good formatter"
+
+        help_str = environ.generate_help(Parent, formatter=bad_formatter)
+        assert help_str == "Not a good formatter"


### PR DESCRIPTION
Functionality inspired by the help kwarg on [argparse.ArgumentParser.add_argument](https://docs.python.org/3/library/argparse.html#the-add-argument-method).

Allows users to specify a help value when declaring env vars on a configuration class, and provides a helper function to produce a help string for a configuration object dynamically.

Example:

```python
import environ

from attr.validators import in_

@environ.config(prefix="APP")
class Configuration:
    username = environ.var(help="The username to use for...")
    auto_connect = environ.bool_var(
        True,
        help="Auto connect to..."
    )
    verbosity = environ.var(
        "WARNING",
        validator=in_(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
        help="The verbosity to log at"
    )

    @environ.config
    class MongoConfig:
        host = environ.var(
            "localhost",
            help="The host name of the mongodb server"
        )
        port = environ.var(
            27018,
            help="The port to connect to the monodb server on."
        )
        db_name = environ.var(
            help="The name of the database to use for..."
        )

    mongo = environ.group(MongoConfig)


if __name__ == "__main__":
    print(
        environ.generate_help(Configuration, display_defaults=True)
    )
```
yields...
```
APP_USERNAME (Required): The username to use for...
APP_AUTO_CONNECT (Optional, Default=True): Auto connect to...
APP_VERBOSITY (Optional, Default=WARNING): The verbosity to log at
APP_MONGO_HOST (Optional, Default=localhost): The host name of the mongodb server
APP_MONGO_PORT (Optional, Default=27018): The port to connect to the monodb server on.
APP_MONGO_DB_NAME (Required): The name of the database to use for...
```

Additionally: Fixes a weird interplay between black and isort, which would cause the lint step to fail ad-infintum.