### PR TITLE
Fix test _SecretStr on attrs>=18.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = ["attrs>=17.4.0"]
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "coverage"]
+    "tests": ["pytest", "coverage", "tox"]
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"]
 
@@ -77,7 +77,7 @@ LONG = (
     read("README.rst") + "\n\n" +
     "Release Information\n" +
     "===================\n\n" +
-    re.search("(\d+.\d.\d \(.*?\)\n.*?)(\n\n\n----\n)",
+    re.search(r"(\d+.\d.\d \(.*?\)\n.*?)(\n\n\n----\n)",
               read("CHANGELOG.rst"), re.S).group(1) +
     "\n\n`Full changelog " +
     "<{uri}en/stable/changelog.html>`_.\n\n".format(uri=URI) +

--- a/src/environ/secrets.py
+++ b/src/environ/secrets.py
@@ -116,7 +116,8 @@ class _SecretStr(str):
     String that censors its __repr__ if called from an attrs repr.
     """
     def __repr__(self):
-        f = sys._getframe(2)
+        depth = 2 if attr.__version__.startswith('17') else 1
+        f = sys._getframe(depth)
 
         if f.f_code.co_name == "__repr__":
             return "<SECRET>"


### PR DESCRIPTION
Add tox to tests requirements
Remove warnings due to non-raw regex patterns