### PR TITLE
Created config class got `from_environ` method (fix #2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changes:
 ^^^^^^^^
 
 - Added ``environ.generate_help(AppConfig)`` to create a help string based on the configuration.
+- Added ``AppConfig.from_environ`` to instantiate config without importing ``environ`` module.
 
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,8 @@ environ_config: Configuration with env variables for Python.
   ...    lang = environ.var(name="LANG")  # It's possible to overwrite the names of variables.
   ...    db = environ.group(DB)
   ...    awesome = environ.bool_var()
-  >>> cfg = AppConfig.from_environ(
+  >>> cfg = environ.to_config(
+  ...     AppConfig,
   ...     environ={
   ...         "APP_ENV": "dev",
   ...         "APP_DB_HOST": "localhost",
@@ -51,23 +52,7 @@ environ_config: Configuration with env variables for Python.
   >>> cfg.db.password
   's3kr3t'
 
-`AppConfig` instance can be also created by means of `environ.to_config` method:
-
-.. code-block:: pycon
-
-  >>> cfg = environ.to_config(AppConfig,
-  ...     environ={
-  ...         "APP_ENV": "dev",
-  ...         "APP_DB_HOST": "localhost",
-  ...         "LANG": "C",
-  ...         "APP_AWESOME": "yes",  # true and 1 work too, everything else is False
-  ...         # Vault-via-envconsul-style var name:
-  ...         "SECRET_YOUR_APP_DB_PASSWORD": "s3kr3t",
-  ... })  # Uses os.environ by default.
-  >>> cfg
-  AppConfig(env='dev', lang='C', db=AppConfig.DB(name='default_db', host='localhost', port=5432, user='default_user', password=<SECRET>), awesome=True)
-  >>> cfg.db.password
-  's3kr3t'
+``AppConfig.from_environ({...})`` is equivalent to the code above, depending on your taste.
 
 Features
 ========

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,7 @@ environ_config: Configuration with env variables for Python.
   ...    lang = environ.var(name="LANG")  # It's possible to overwrite the names of variables.
   ...    db = environ.group(DB)
   ...    awesome = environ.bool_var()
-  >>> cfg = environ.to_config(
-  ...     AppConfig,
+  >>> cfg = AppConfig.from_environ(
   ...     environ={
   ...         "APP_ENV": "dev",
   ...         "APP_DB_HOST": "localhost",
@@ -52,6 +51,23 @@ environ_config: Configuration with env variables for Python.
   >>> cfg.db.password
   's3kr3t'
 
+`AppConfig` instance can be also created by means of `environ.to_config` method:
+
+.. code-block:: pycon
+
+  >>> cfg = environ.to_config(AppConfig,
+  ...     environ={
+  ...         "APP_ENV": "dev",
+  ...         "APP_DB_HOST": "localhost",
+  ...         "LANG": "C",
+  ...         "APP_AWESOME": "yes",  # true and 1 work too, everything else is False
+  ...         # Vault-via-envconsul-style var name:
+  ...         "SECRET_YOUR_APP_DB_PASSWORD": "s3kr3t",
+  ... })  # Uses os.environ by default.
+  >>> cfg
+  AppConfig(env='dev', lang='C', db=AppConfig.DB(name='default_db', host='localhost', port=5432, user='default_user', password=<SECRET>), awesome=True)
+  >>> cfg.db.password
+  's3kr3t'
 
 Features
 ========

--- a/src/environ/_environ_config.py
+++ b/src/environ/_environ_config.py
@@ -38,7 +38,13 @@ RAISE = Raise()
 
 def config(maybe_cls=None, prefix="APP"):
     def wrap(cls):
+        def from_environ(cls, environ=os.environ):
+            import environ as environ_config
+
+            return environ_config.to_config(cls, environ)
+
         cls._prefix = prefix
+        cls.from_environ = classmethod(from_environ)
         return attr.s(cls, slots=True)
 
     if maybe_cls is None:

--- a/tests/test_class_to_config.py
+++ b/tests/test_class_to_config.py
@@ -1,8 +1,4 @@
 from __future__ import absolute_import, division, print_function
-import os
-
-import attr
-import pytest
 
 import environ
 

--- a/tests/test_class_to_config.py
+++ b/tests/test_class_to_config.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, division, print_function
+import os
+
+import attr
+import pytest
+
+import environ
+
+
+@environ.config(prefix="APP")
+class AppConfig(object):
+    host = environ.var("127.0.0.1")
+    port = environ.var(5000, converter=int)
+
+
+def test_default():
+    cfg = AppConfig.from_environ()
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 5000
+
+
+def test_env():
+    env = {"APP_HOST": "0.0.0.0"}
+    cfg = AppConfig.from_environ(environ=env)
+    assert cfg.host == "0.0.0.0"
+    assert cfg.port == 5000

--- a/tests/test_class_to_config.py
+++ b/tests/test_class_to_config.py
@@ -10,12 +10,16 @@ class AppConfig(object):
 
 
 def test_default():
+    """Class based `from_environ` without `environ` argument.
+    """
     cfg = AppConfig.from_environ()
     assert cfg.host == "127.0.0.1"
     assert cfg.port == 5000
 
 
 def test_env():
+    """Class based `from_environ`  with explicit `environ` argument.
+    """
     env = {"APP_HOST": "0.0.0.0"}
     cfg = AppConfig.from_environ(environ=env)
     assert cfg.host == "0.0.0.0"


### PR DESCRIPTION
Modified `@environ.config` decorator to add classmethod `from_environ` to each created class.

This PR does not add any other method (such as `generate_help`)